### PR TITLE
Renaming XML Parser to Text Parser

### DIFF
--- a/app/controllers/misc_controller.rb
+++ b/app/controllers/misc_controller.rb
@@ -1,7 +1,7 @@
 class MiscController < ApplicationController
   include ApiHelper
 
-  def xml_parse
+  def text_parse
     @output = {}
 
     if params[:input_form].present?

--- a/app/helpers/api_helper.rb
+++ b/app/helpers/api_helper.rb
@@ -11,7 +11,7 @@ module ApiHelper
                                                  :ssl_verifyhost => 0 ) #Server is set as verified but without proper certification.
     elsif type == 'JSON'
       service_response = Typhoeus::Request.post( path,
-                                                 headers: {'Content-Type' => 'text/json'},
+                                                 headers: {'Content-Type' => 'application/json'},
                                                  body: input,
                                                  :ssl_verifyhost => 0 ) #Server is set as verified but without proper certification.
     end

--- a/app/views/misc/text_parse.html.erb
+++ b/app/views/misc/text_parse.html.erb
@@ -1,4 +1,4 @@
-<% provide(:title, "XML Parser") %>
+<% provide(:title, "Text Parser") %>
 
 <div class="form">
   <div class="col-md-6 col-md-offset-3">

--- a/app/views/static_pages/main.html.erb
+++ b/app/views/static_pages/main.html.erb
@@ -16,6 +16,6 @@
 
 <h3>Miscellaneous</h3>
 <ul>
-  <li><%= link_to "XML Parser", xmlparse_path %>:
-     Parses XML in a text field and allows it to be sent directly to the web services test server.</li>
+  <li><%= link_to "Text Parser", textparse_path %>:
+     Parses raw text input as a request and allows it to be sent directly to the web services test server.</li>
 </ul>

--- a/app/views/static_pages/misc.html.erb
+++ b/app/views/static_pages/misc.html.erb
@@ -1,5 +1,5 @@
 <% provide(:title, "Miscellaneous") %>
 <ul>
-  <li><%= link_to "XML Parser", xmlparse_path %>:
-     Parses XML in a text field and allows it to be sent directly to the web services test server.</li>
+  <li><%= link_to "Text Parser", textparse_path %>:
+     Parses raw text input as a request and allows it to be sent directly to the web services test server.</li>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root 'static_pages#main'
   get  '/service', to: 'static_pages#service'
   get  '/misc', to: 'static_pages#misc'
-  
+
   get  '/utility', to: 'services#utility'
   get  '/availability', to: 'services#availability'
   get  '/calculate', to: 'services#calculate'
@@ -12,6 +12,6 @@ Rails.application.routes.draw do
   get  '/reservationcreate', to: 'services#res_create'
   get  '/sitecancel', to: 'services#site_cancel'
   get  '/reservationreverse', to: 'services#res_reverse'
-  
-  get  '/xmlparse', to: 'misc#xml_parse'
+
+  get  '/textparse', to: 'misc#text_parse'
 end

--- a/test/controllers/misc_controller_test.rb
+++ b/test/controllers/misc_controller_test.rb
@@ -9,7 +9,7 @@ class MiscControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'xml parse: should be setup properly' do
-    get xmlparse_path
+    get textparse_path
     assert_response :success
     assert_select 'title', 'BYS Web Sandbox: XML Parser'
 


### PR DESCRIPTION
The parser now submits as XML or JSON, so its name wasn't appropiate anymore.